### PR TITLE
feat(deprecations): fix deprecation mesages :D

### DIFF
--- a/src/AvroFactory.php
+++ b/src/AvroFactory.php
@@ -43,7 +43,7 @@ readonly class AvroFactory implements AvroFactoryInterface
         return new Writer($parsedSchema, $datumWriter);
     }
 
-    public function createReader(string $writerSchema, string $readerSchema = null): ReaderInterface
+    public function createReader(string $writerSchema, ?string $readerSchema = null): ReaderInterface
     {
         $parsedWriterSchema = AvroSchema::parse($writerSchema);
         $parsedReaderSchema = $readerSchema === null ? $parsedWriterSchema : AvroSchema::parse($readerSchema);

--- a/src/Contracts/AvroFactoryInterface.php
+++ b/src/Contracts/AvroFactoryInterface.php
@@ -8,7 +8,7 @@ interface AvroFactoryInterface
 {
     public function createWriter(string $schema): WriterInterface;
 
-    public function createReader(string $writerSchema, string $readerSchema = null): ReaderInterface;
+    public function createReader(string $writerSchema, ?string $readerSchema = null): ReaderInterface;
 
     public function createStringBuffer(): StringBufferInterface;
 


### PR DESCRIPTION
This fixes: 

```
Deprecated: Auxmoney\Avro\Contracts\AvroFactoryInterface::createReader(): Implicitly marking parameter $readerSchema as nullable is deprecated, the explicit nullable type must be used instead 

Deprecated: Auxmoney\Avro\AvroFactory::createReader(): Implicitly marking parameter $readerSchema as nullable is deprecated, the explicit nullable type must be used instead 
```